### PR TITLE
Added read_timeout option

### DIFF
--- a/lib/mailgunner.rb
+++ b/lib/mailgunner.rb
@@ -23,6 +23,7 @@ module Mailgunner
       end
 
       @http = Net::HTTP.new('api.mailgun.net', Net::HTTP.https_default_port)
+      @http.read_timeout = options.fetch(:read_timeout) if options.key?(:read_timeout)
 
       @http.use_ssl = true
     end


### PR DESCRIPTION
Pretty simple—passes on `read_timeout` to underlying `Net::HTTP` client.
